### PR TITLE
MScMap - generate multiple synonymous coding sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Zur and Tuller. Exploiting hidden information interleaved in the redundancy of t
 
 - **Position-Specific ChimeraARS (PScARS)**: calculates an extended version of the ARS score that takes into account the position of each sub-sequence in the target and in the reference genes. (Diament et al., 2019)
 
+- **Multi-sequence ChimeraMap (MScMap)**: generates multiple optimized variants of the target protein for use in multi-copy systems. (Burghardt et al., 2025)
+
 ## Benchmark: Python vs. MATLAB
 
 the following table shows the runtime in seconds for each algorithm, when using the Python package with multiprocessing, on a single core, or in MATLAB. this test was done on a 2015 MacBook Pro.
@@ -90,7 +92,7 @@ this example demonstrates a run on the codon alphabet (the recommended approach 
 
 ### Engineering / Design
 
-similarly, running cMap or PScMap requires two steps:
+similarly, running cMap, PScMap or MScMap requires two steps:
 
 ```python
 SA_aa = build_suffix_array(ref_aa)
@@ -105,6 +107,10 @@ target_optim_nt = calc_cMap(target_aa, SA_aa, ref_nt,
 # Position-Specific Chimera Map (PScMap)
 target_optim_nt = calc_cMap(target_aa, SA_aa, ref_nt,
     win_params=win_params, max_len=max_len, max_pos=max_pos)
+
+# Multi-sequence Chimera Map (MScMap)
+target_optim_nts = calc_cMap(target_aa, SA_aa, ref_nt,
+    win_params=win_params, max_len=max_len, max_pos=max_pos, n_seqs=5, min_blocks=2)
 ```
 
 this function also accepts an iterable of strings as the target sequence, and uses multiprocessing to run the batch efficiently.

--- a/chimera/chimera.py
+++ b/chimera/chimera.py
@@ -185,7 +185,8 @@ def calc_cMap(target_aa, SA_aa, ref_nt, win_params=None, max_len=np.inf, max_pos
 
     if (np.array(nt2aa(target_opt)) != target_aa).any():
         raise ValueError('non-syonymous optimization')
-
+    if n_seqs == 1:
+        return target_opt[0]
     return target_opt
 
 

--- a/chimera/chimera.py
+++ b/chimera/chimera.py
@@ -101,6 +101,11 @@ def calc_cMap(target_aa, SA_aa, ref_nt, win_params=None, max_len=np.inf, max_pos
             the 'all' method outputs all equally-optimal unique synonymous
             blocks, and in this case the `max_pos` param is ignored. value
             in {'most_freq', 'all'}, defaults to 'most_freq'.
+        n_seqs: number of sequences to generate
+        min_blocks: Minimum number of unique nucleotide blocks per amino acid block.
+            Set to >1 when generating multiple sequence variants to make variants more different
+            from each other.
+        return_vec: if True, return a vector with all possible nucleotide blocks.
         n_jobs: number of parallel jobs to run. if None, use all available cores.
 
         Alon Diament / Tuller Lab, July 2015 (MATLAB), June 2022 (Python).
@@ -121,10 +126,9 @@ def calc_cMap(target_aa, SA_aa, ref_nt, win_params=None, max_len=np.inf, max_pos
 
     n = len(target_aa)
     SA_aa['homologs'] = set()  # empty mask
+    homologs = np.full(1, -1)  # initialize
 
-    pos_pass = False
-
-    while not pos_pass:
+    while homologs.size > 0:
         all_blocks = []
         cmap_origin = np.zeros(len(SA_aa["ind"]), dtype=int)
         pos = 0  # position in target
@@ -137,7 +141,7 @@ def calc_cMap(target_aa, SA_aa, ref_nt, win_params=None, max_len=np.inf, max_pos
                 raise ValueError('empty block at {}/{}, suffix starts with: "{}"'
                                  .format(pos, len(target_aa), target_aa[pos:pos + 10]))
 
-            prev_blocks = np.empty(shape=0)
+            prev_blocks = []
             prev_block_aa = ""
             while len(block_aa) > 0:
                 blocks, i_prefixes = get_all_nt_blocks(block_aa, SA_aa, ref_nt)
@@ -165,8 +169,6 @@ def calc_cMap(target_aa, SA_aa, ref_nt, win_params=None, max_len=np.inf, max_pos
 
         homologs = np.argwhere(cmap_origin / n > max_pos).flatten()
         SA_aa['homologs'].update(homologs)
-        if homologs.size == 0:
-            pos_pass = True
 
     if return_vec:
         return all_blocks

--- a/chimera/suffix_array.py
+++ b/chimera/suffix_array.py
@@ -98,11 +98,13 @@ def most_freq_nt_prefix(pref_aa, SA_aa, ref_nt):
 
 
 def get_all_nt_blocks(pref_aa, SA_aa, ref_nt):
+    """ finds the all *NT* prefixes in `SA_aa` that codes the given
+            AA prefix `pref_aa`.
+    """
     n = len(pref_aa)
     left = search_suffix(pref_aa, SA_aa)
     right = search_suffix(pref_aa + '~', SA_aa)
-    if left == right:
-        right += 1
+
     i_prefix = [i for i in range(left, right)
                 if not is_suffix_masked(SA_aa, i)]
 

--- a/chimera/suffix_array.py
+++ b/chimera/suffix_array.py
@@ -83,20 +83,6 @@ def longest_prefix(key, SA, max_len=np.inf):
     return pref, pind
 
 
-def most_freq_nt_prefix(pref_aa, SA_aa, ref_nt):
-    """ finds the most frequent *NT* prefix in `SA_aa` that codes the given 
-        AA prefix `pref_aa`.
-    """
-    all_blocks, i_prefix = get_all_nt_blocks(pref_aa, SA_aa, ref_nt)
-
-    block = Counter(sorted(all_blocks)).most_common(1)[0][0]  # first in lexicographic order
-    mostfreq = [i for i, b in zip(i_prefix, all_blocks) if block == b][0]
-    gene = SA_aa['ind'][mostfreq]
-    loc = SA_aa['pos'][mostfreq]
-
-    return gene, loc, block
-
-
 def get_all_nt_blocks(pref_aa, SA_aa, ref_nt):
     """ finds the all *NT* prefixes in `SA_aa` that codes the given
             AA prefix `pref_aa`.

--- a/chimera/suffix_array.py
+++ b/chimera/suffix_array.py
@@ -1,6 +1,6 @@
 # Alon Diament, Tuller Lab, June 2022.
 
-from collections import defaultdict, Counter
+from collections import defaultdict
 from itertools import repeat
 import math
 from multiprocessing.pool import Pool


### PR DESCRIPTION
This PR adds an extension of the ChimeraMap algorithm that generates multiple synonymous sequences.

It is integrated into the existing calc_cMap function. The behaviour changes slightly:
a) we now return a list of optimized sequences (of length 1 for the default chimeraMap)
b) the max_pos filter is adapted and now tracks all the genes that contain the chosen aa block (not just the one of the chosen nt block as previously).

If that is a problem I can also make it a separate function.